### PR TITLE
Enable macOS app background launch and window pinning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,9 @@ package.products.append(
 package.targets.append(
     .executableTarget(
         name: "tdo-mac",
-        dependencies: ["TDOCore"],
-        path: "Sources/tdo-mac"
+        dependencies: ["TDOCore", "TDOTerminal"],
+        path: "Sources/tdo-mac",
+        exclude: ["Info.plist"]
     )
 )
 #endif

--- a/Sources/TDOCore/Engine.swift
+++ b/Sources/TDOCore/Engine.swift
@@ -42,6 +42,11 @@ public struct Engine {
 
             case .act(let ids, let action, let status):
                 return try perform(ids: ids, action: action, status: status, env: env)
+
+            case .pin, .unpin:
+                return (["note: pin/unpin handled by macOS app"], false, .ok)
+            case .exit:
+                return (["note: exit handled by macOS app"], false, .ok)
             }
         } catch let e as FileIOError {
             return (["error: \(e)"], false, .ioError)

--- a/Sources/TDOCore/Parser.swift
+++ b/Sources/TDOCore/Parser.swift
@@ -11,6 +11,9 @@ public enum Command {
     case undo
     case show(String)  // NEW
     case act([String], Action, String?)
+    case pin
+    case unpin
+    case exit
 }
 
 enum ParseError: Error, CustomStringConvertible {
@@ -36,6 +39,9 @@ public struct Parser {
         if first == "list" { return .list }
         if first == "find" { return .find(argv.dropFirst().joined(separator: " ").nilIfEmpty()) }
         if first == "foo" { return .foo(argv.dropFirst().joined(separator: " ").nilIfEmpty()) }
+        if first == "pin" { return .pin }
+        if first == "unpin" { return .unpin }
+        if first == "exit" { return .exit }
 
         // action-first sugar
         if first == "done" || first == "remove" {

--- a/Sources/tdo-mac/App.swift
+++ b/Sources/tdo-mac/App.swift
@@ -6,25 +6,73 @@ extension Notification.Name {
     static let tdoUndo = Notification.Name("tdoUndo")
     static let tdoRefresh = Notification.Name("tdoRefresh")
     static let tdoFocusCommand = Notification.Name("tdoFocusCommand")
+    static let tdoPin = Notification.Name("tdoPin")
+    static let tdoUnpin = Notification.Name("tdoUnpin")
+    static let tdoExit = Notification.Name("tdoExit")
+}
+
+final class PinObserver: ObservableObject {
+    @Published var isPinned = false
+
+    private var observers: [NSObjectProtocol] = []
+
+    init() {
+        let center = DistributedNotificationCenter.default()
+        observers.append(
+            center.addObserver(forName: .tdoPin, object: nil, queue: .main) { [weak self] _ in
+                self?.isPinned = true
+                self?.applyPin()
+            }
+        )
+        observers.append(
+            center.addObserver(forName: .tdoUnpin, object: nil, queue: .main) { [weak self] _ in
+                self?.isPinned = false
+                self?.applyPin()
+            }
+        )
+        observers.append(
+            center.addObserver(forName: .tdoExit, object: nil, queue: .main) { _ in
+                NSApp.terminate(nil)
+            }
+        )
+    }
+
+    deinit {
+        let center = DistributedNotificationCenter.default()
+        for observer in observers {
+            center.removeObserver(observer)
+        }
+    }
+
+    func applyPin() {
+        for window in NSApp.windows {
+            window.level = isPinned ? .floating : .normal
+        }
+    }
 }
 
 @main
 struct TDOMacApp: App {
+    @StateObject private var pinObserver = PinObserver()
+
     init() {
         DispatchQueue.main.async {
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
+            if let image = NSImage(systemSymbolName: "checkmark.circle", accessibilityDescription: nil) {
+                NSApp.applicationIconImage = image
+            }
         }
     }
 
     var body: some Scene {
         WindowGroup("tdo") {
             ContentView(engine: Engine(), env: try! Env())
+                .environmentObject(pinObserver)
                 .frame(
                     minWidth: 720, idealWidth: 720, maxWidth: .infinity,
                     minHeight: 460, maxHeight: .infinity)
         }
-        .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(replacing: .appTermination) {
                 Button("Quit tdo") { NSApp.terminate(nil) }
@@ -40,6 +88,11 @@ struct TDOMacApp: App {
                 Button("Focus Command") {
                     NotificationCenter.default.post(name: .tdoFocusCommand, object: nil)
                 }.keyboardShortcut("l", modifiers: [.command])
+                Divider()
+                Button(pinObserver.isPinned ? "Unpin Window" : "Pin Window") {
+                    pinObserver.isPinned.toggle()
+                    pinObserver.applyPin()
+                }
             }
         }
     }

--- a/Sources/tdo-mac/ContentView.swift
+++ b/Sources/tdo-mac/ContentView.swift
@@ -1,22 +1,33 @@
 import AppKit
 import SwiftUI
 import TDOCore
+import TDOTerminal
 
 final class ViewModel: ObservableObject {
     @Published var tasks: [OpenTask] = []
+    @Published var lines: [String]? = nil
     @Published var command: String = ""
     @Published var status: String? = nil  // last action / feedback
     @Published var selectedIndex: Int? = nil  // keyboard selection
+    @Published var title: String = "tdo"
 
     private let engine: Engine
     private let env: Env
     private let age = AgeLabeler()
     private let mask: TimestampMasker
+    private let renderer: Renderer
 
     init(engine: Engine, env: Env) {
         self.engine = engine
         self.env = env
         self.mask = TimestampMasker(age: age)
+        self.renderer = Renderer(
+            config: RenderConfig(
+                colorize: false,
+                blankLineBeforeBlock: false,
+                blankLineAfterBlock: false
+            )
+        )
         refresh()
     }
 
@@ -24,6 +35,8 @@ final class ViewModel: ObservableObject {
         do {
             let all = try engine.openTasks(env: env)
             tasks = all.sorted(by: { $0.createdAt > $1.createdAt })
+            lines = nil
+            title = "tdo"
             if selectedIndex.map({ $0 >= tasks.count }) ?? false {
                 selectedIndex = tasks.isEmpty ? nil : 0
             }
@@ -44,6 +57,13 @@ final class ViewModel: ObservableObject {
         let cmd: Command
         do { cmd = try Parser.parse(argv: argv) } catch { cmd = .do_(line) }
 
+        // Special handling for list to restore open tasks
+        if case .list = cmd {
+            refresh()
+            status = nil
+            return
+        }
+
         // Special handling for show: collapse to a single status line
         if case .show(let pfx) = cmd {
             let (lines, _, _) = engine.execute(cmd, env: env)
@@ -56,22 +76,54 @@ final class ViewModel: ObservableObject {
             return
         }
 
+        // Special handling for find/foo: render lines and update title
+        if case .find(let q) = cmd {
+            let (out, _, _) = engine.execute(cmd, env: env)
+            lines = renderer.render(out)
+            title = "tdo - find" + ((q ?? "").isEmpty ? "" : " [\(q!)]")
+            status = nil
+            selectedIndex = nil
+            command = ""  // clear search field
+            return
+        }
+        if case .foo(let q) = cmd {
+            let (out, _, _) = engine.execute(cmd, env: env)
+            lines = renderer.render(out)
+            title = "tdo - foo" + ((q ?? "").isEmpty ? "" : " [\(q!)]")
+            status = nil
+            selectedIndex = nil
+            command = ""  // clear search field
+            return
+        }
+
+#if os(macOS)
+        if case .pin = cmd {
+            DistributedNotificationCenter.default().post(name: .tdoPin, object: nil)
+            status = "pinned window"
+            command = ""
+            return
+        }
+        if case .unpin = cmd {
+            DistributedNotificationCenter.default().post(name: .tdoUnpin, object: nil)
+            status = "unpinned window"
+            command = ""
+            return
+        }
+        if case .exit = cmd {
+            NSApp.terminate(nil)
+            return
+        }
+#endif
+
         let (out, mutated, _) = engine.execute(cmd, env: env)
         status = out.first
-        if mutated || isListy(cmd) { refresh() }
-        if mutated { command = "" }
+        if mutated { refresh(); command = "" }
     }
 
     func undoLast() {
         let (lines, mutated, _) = engine.execute(.undo, env: env)
         if let first = lines.first { status = first }
         if mutated { refresh() }
-    }
-
-    func isListy(_ cmd: Command) -> Bool {
-        if case .list = cmd { return true }
-        if case .find = cmd { return true }
-        return false
     }
 
     func ageLabel(_ t: OpenTask) -> String { age.label(createdAt: t.createdAt) }
@@ -123,6 +175,7 @@ struct CommandField: NSViewRepresentable {
     var onDown: () -> Void
     var onPageUp: () -> Void
     var onPageDown: () -> Void
+    var onEscape: () -> Void
 
     final class Coordinator: NSObject, NSTextFieldDelegate, NSControlTextEditingDelegate {
         var parent: CommandField
@@ -152,6 +205,9 @@ struct CommandField: NSViewRepresentable {
             case #selector(NSResponder.pageDown(_:)):
                 parent.onPageDown()
                 return true
+            case #selector(NSResponder.cancelOperation(_:)):
+                parent.onEscape()
+                return true
             default:
                 return false
             }
@@ -163,14 +219,14 @@ struct CommandField: NSViewRepresentable {
     func makeNSView(context: Context) -> NSTextField {
         let tf = NSTextField(string: text)
         tf.isBordered = false
+        tf.isBezeled = false
         tf.focusRingType = .none
-        tf.drawsBackground = true
-        tf.wantsLayer = true
-        tf.layer?.cornerRadius = 6
-        tf.backgroundColor = NSColor.windowBackgroundColor
-        tf.textColor = NSColor.labelColor
+        tf.drawsBackground = false
+        tf.backgroundColor = .clear
+        tf.textColor = .white
+        tf.insertionPointColor = .white
         tf.placeholderString = placeholder
-        tf.font = NSFont.systemFont(ofSize: 15)
+        tf.font = NSFont.monospacedSystemFont(ofSize: 15, weight: .regular)
         tf.delegate = context.coordinator
 
         if focusOnAppear, !context.coordinator.didFocusOnce {
@@ -195,20 +251,44 @@ struct CommandField: NSViewRepresentable {
 struct ContentView: View {
     @StateObject private var vm: ViewModel
     @State private var pageStep: Int = 10
+    @EnvironmentObject private var pinObserver: PinObserver
 
     init(engine: Engine, env: Env) {
         _vm = StateObject(wrappedValue: ViewModel(engine: engine, env: env))
+    }
+
+    private func styled(_ line: String) -> Text {
+        if line.hasPrefix("added:") || line.hasPrefix("done:") || line.hasPrefix("undo:") {
+            return Text(line).foregroundColor(.green)
+        }
+        if line.hasPrefix("remove:") { return Text(line).foregroundColor(.red) }
+        if line.hasPrefix("error:") { return Text(line).foregroundColor(.red).bold() }
+        if line.hasPrefix("note:") { return Text(line).foregroundColor(.gray) }
+        if line.contains(" @ ") && line.contains(" status: ") { return Text(line).foregroundColor(.gray) }
+        if line.hasPrefix("["), let close = line.firstIndex(of: "]") {
+            let uid = String(line[..<line.index(after: close)])
+            let rest = String(line[line.index(after: close)...])
+            return Text(uid).foregroundColor(.cyan) + Text(rest)
+        }
+        return Text(line)
     }
 
     var body: some View {
         VStack(spacing: 8) {
             // Status line
             HStack {
-                Text(vm.status ?? "\(vm.tasks.count) open")
-                    .font(.system(size: 14))
-                    .foregroundColor(.gray)
-                    .lineLimit(3)
-                    .multilineTextAlignment(.leading)
+                if let status = vm.status {
+                    styled(status)
+                        .font(.system(size: 14, design: .monospaced))
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                } else if let lines = vm.lines {
+                    Text("\(lines.count) results")
+                        .font(.system(size: 14, design: .monospaced))
+                } else {
+                    Text("\(vm.tasks.count) open")
+                        .font(.system(size: 14, design: .monospaced))
+                }
                 Spacer()
             }
 
@@ -216,27 +296,48 @@ struct ContentView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(vm.tasks.enumerated()), id: \.element.uid) { idx, t in
-                            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                                Text("[\(t.uid)]").font(.system(size: 15, design: .monospaced))
-                                Text(t.text).font(.system(size: 15)).lineLimit(1).truncationMode(.tail)
-                                Spacer(minLength: 12)
-                                Text("· \(vm.ageLabel(t))").foregroundColor(.gray).font(.system(size: 13))
+                        if let lines = vm.lines {
+                            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                                styled(line)
+                                    .font(.system(size: 15, design: .monospaced))
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                             }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(
-                                vm.selectedIndex == idx ? Color.accentColor.opacity(0.12) : .clear
-                            )
-                            .contentShape(Rectangle())
-                            .onTapGesture { vm.selectTask(idx) }
-                            .id(t.uid)
+                        } else {
+                            ForEach(Array(vm.tasks.enumerated()), id: \.element.uid) { idx, t in
+                                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                    Text("[\(t.uid)]")
+                                        .foregroundColor(.cyan)
+                                        .font(.system(size: 15, design: .monospaced))
+                                    Text(t.text)
+                                        .foregroundColor(.white)
+                                        .font(.system(size: 15, design: .monospaced))
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                    Spacer(minLength: 12)
+                                    Text("· \(vm.ageLabel(t))")
+                                        .foregroundColor(.gray)
+                                        .font(.system(size: 13, design: .monospaced))
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(
+                                    vm.selectedIndex == idx ? Color.accentColor.opacity(0.12) : .clear
+                                )
+                                .contentShape(Rectangle())
+                                .onTapGesture { vm.selectTask(idx) }
+                                .id(t.uid)
+                            }
                         }
                     }
                 }
                 .onChange(of: vm.selectedIndex) { newIdx in
-                    guard let newIdx, newIdx >= 0, newIdx < vm.tasks.count else { return }
+                    guard vm.lines == nil,
+                          let newIdx,
+                          newIdx >= 0,
+                          newIdx < vm.tasks.count else { return }
                     withAnimation(.easeInOut(duration: 0.15)) {
                         proxy.scrollTo(vm.tasks[newIdx].uid, anchor: .center)
                     }
@@ -244,23 +345,64 @@ struct ContentView: View {
             }
 
             // COMMAND FIELD (captures ⏎, ↑/↓, PgUp/PgDn)
-            CommandField(
-                text: $vm.command,
-                placeholder:
-                    "Type a command or just text…  (e.g.  do buy coffee   |   ABC done   |   undo)",
-                focusOnAppear: true,
-                onSubmit: { vm.submit() },
-                onUp: { vm.moveSelection(by: -1) },
-                onDown: { vm.moveSelection(by: +1) },
-                onPageUp: { vm.moveSelection(by: -pageStep) },
-                onPageDown: { vm.moveSelection(by: +pageStep) }
-            )
-            .frame(height: 30)
+            HStack(spacing: 8) {
+                CommandField(
+                    text: $vm.command,
+                    placeholder:
+                        "Type a command or just text…  (e.g.  do buy coffee   |   ABC done   |   undo)",
+                    focusOnAppear: true,
+                    onSubmit: { vm.submit() },
+                    onUp: { vm.moveSelection(by: -1) },
+                    onDown: { vm.moveSelection(by: +1) },
+                    onPageUp: { vm.moveSelection(by: -pageStep) },
+                    onPageDown: { vm.moveSelection(by: +pageStep) },
+                    onEscape: {
+                        if vm.lines != nil {
+                            vm.refresh()
+                        }
+                    }
+                )
+                .frame(height: 28)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 12)
+                .background(Color(white: 0.15))
+                .cornerRadius(20)
+            }
             .padding(.top, 8)
         }
         .padding(20)
-        .background(Color(NSColor.windowBackgroundColor))
+        .foregroundColor(.white)
+        .background(Color.black)
         .preferredColorScheme(.dark)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(vm.title)
+                    .font(.system(size: 16, design: .monospaced))
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: {
+                    pinObserver.isPinned.toggle()
+                    pinObserver.applyPin()
+                }) {
+                    Image(systemName: pinObserver.isPinned ? "pin.fill" : "pin")
+                        .rotationEffect(.degrees(45))
+                }
+            }
+        }
+        .onAppear {
+            // Blend title bar with the task list area
+            if let window = NSApp.windows.first {
+                window.titleVisibility = .hidden
+                window.titlebarAppearsTransparent = true
+                window.backgroundColor = .black
+                window.title = vm.title
+            }
+        }
+        .onChange(of: vm.title) { newTitle in
+            if let window = NSApp.windows.first {
+                window.title = newTitle
+            }
+        }
         // Optional hotkeys from App.swift (if you kept those commands)
         .onReceive(NotificationCenter.default.publisher(for: .tdoUndo)) { _ in vm.undoLast() }
         .onReceive(NotificationCenter.default.publisher(for: .tdoRefresh)) { _ in vm.refresh() }

--- a/Sources/tdo-mac/Info.plist
+++ b/Sources/tdo-mac/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>tdo</string>
+    <key>CFBundleDisplayName</key>
+    <string>tdo</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.tdo</string>
+</dict>
+</plist>

--- a/Sources/tdo/main.swift
+++ b/Sources/tdo/main.swift
@@ -1,6 +1,13 @@
 import Foundation
 import TDOCore
 import TDOTerminal
+#if os(macOS)
+extension Notification.Name {
+    static let tdoPin = Notification.Name("tdoPin")
+    static let tdoUnpin = Notification.Name("tdoUnpin")
+    static let tdoExit = Notification.Name("tdoExit")
+}
+#endif
 
 // Parse global flags: --file, --archive (best-effort; stripped from argv)
 func splitGlobalFlags(_ args: [String]) -> (paths: (String?, String?), rest: [String]) {
@@ -61,7 +68,12 @@ func runShell(env: Env) -> Int32 {
         }
 
         let lower = trimmed.lowercased()
-        if lower == "exit" || lower == "quit" { break }
+        if lower == "exit" || lower == "quit" {
+#if os(macOS)
+            DistributedNotificationCenter.default().post(name: .tdoExit, object: nil)
+#endif
+            break
+        }
 
         let argv = trimmed.split(separator: " ").map(String.init)
         do {
@@ -72,6 +84,21 @@ func runShell(env: Env) -> Int32 {
             case .list:
                 let tasks = try engine.openTasks(env: env)
                 renderer.printBlock(renderer.renderOpenList(tasks))
+            case .pin:
+#if os(macOS)
+                DistributedNotificationCenter.default().post(name: .tdoPin, object: nil)
+#endif
+                break
+            case .unpin:
+#if os(macOS)
+                DistributedNotificationCenter.default().post(name: .tdoUnpin, object: nil)
+#endif
+                break
+            case .exit:
+#if os(macOS)
+                DistributedNotificationCenter.default().post(name: .tdoExit, object: nil)
+#endif
+                break
             default:
                 let (lines, mutated, _) = engine.execute(cmd, env: env)
                 renderer.printBlock(lines)
@@ -112,6 +139,30 @@ func runEntry() -> Int32 {
         case .list:
             let tasks = try engine.openTasks(env: env)
             renderer.printBlock(renderer.renderOpenList(tasks))
+            return ExitCode.ok.rawValue
+
+        case .pin:
+#if os(macOS)
+            DistributedNotificationCenter.default().post(name: .tdoPin, object: nil)
+#else
+            renderer.printBlock(["pin is only available on macOS"])
+#endif
+            return ExitCode.ok.rawValue
+
+        case .unpin:
+#if os(macOS)
+            DistributedNotificationCenter.default().post(name: .tdoUnpin, object: nil)
+#else
+            renderer.printBlock(["unpin is only available on macOS"])
+#endif
+            return ExitCode.ok.rawValue
+
+        case .exit:
+#if os(macOS)
+            DistributedNotificationCenter.default().post(name: .tdoExit, object: nil)
+#else
+            renderer.printBlock(["exit is only available on macOS"])
+#endif
             return ExitCode.ok.rawValue
 
         case .do_, .find, .foo, .act, .undo, .show:

--- a/scripts/run-macos-app.sh
+++ b/scripts/run-macos-app.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Build and launch the macOS app without tying up the terminal.
+set -e
+swift build --product tdo-mac
+open ".build/debug/tdo-mac.app" >/dev/null 2>&1 &
+disown
+echo "tdo launched in background"


### PR DESCRIPTION
## Summary
- style macOS app with terminal-like monospaced font and CLI color scheme
- remove ANSI artifacts from macOS find/foo results and clear the command field after showing them
- allow `pin` and `unpin` commands in the macOS command field to toggle window pin state
- show a pin icon in the window toolbar that reflects and toggles pin status
- center the window title with a principal toolbar item and hide the default title text
- remove Ask/Code buttons so the command entry is a single text field
- pass the pin observer into the window scene so the window title displays "tdo" and Cmd–P is no longer required
- center the window title, blend title bar and list colors, and subtly contrast the command bar
- mirror the toolbar pin orientation, remove redundant "tdo" header, and enlarge the command input field
- style the macOS command entry with chat-like Ask/Code buttons
- remove paperclip/microphone icons and guard Code button style for macOS < 12
- treat `exit` as a first-class command, propagating a distributed notification so the macOS app quits when typed in the CLI or app
- match the status line text color with the task list for a unified appearance
- display `find` and `foo` results in the macOS window using the same formatting as the CLI and update the window title accordingly
- exclude macOS Info.plist from SwiftPM build to prevent resource errors
- return to the normal task list with Esc after a `find` or `foo` search

## Testing
- `swift build`
- `swift build --product tdo`
- `swift build --product tdo-mac` *(fails: no product named 'tdo-mac', linux environment)*

------
https://chatgpt.com/codex/tasks/task_e_68af28e15880832eadaf35748e7aa88f