### PR TITLE
Centralize macOS UI strings

### DIFF
--- a/Sources/tdo-mac/App.swift
+++ b/Sources/tdo-mac/App.swift
@@ -88,7 +88,7 @@ struct TDOMacApp: App {
     }
 
     var body: some Scene {
-        WindowGroup("tdo") {
+        WindowGroup(MacStrings.appTitle) {
             ContentView(engine: Engine(), env: env)
                 .environmentObject(pinObserver)
                 .frame(
@@ -97,21 +97,21 @@ struct TDOMacApp: App {
         }
         .commands {
             CommandGroup(replacing: .appTermination) {
-                Button("Quit tdo") { NSApp.terminate(nil) }
+                Button(MacStrings.menuQuit) { NSApp.terminate(nil) }
                     .keyboardShortcut("q", modifiers: [.command])
             }
-            CommandMenu("tdo") {
-                Button("Undo Last") {
+            CommandMenu(MacStrings.menuTitle) {
+                Button(MacStrings.menuUndoLast) {
                     NotificationCenter.default.post(name: .tdoUndo, object: nil)
                 }.keyboardShortcut("z", modifiers: [.command, .shift])
-                Button("Refresh") {
+                Button(MacStrings.menuRefresh) {
                     NotificationCenter.default.post(name: .tdoRefresh, object: nil)
                 }.keyboardShortcut("r", modifiers: [.command])
-                Button("Focus Command") {
+                Button(MacStrings.menuFocusCommand) {
                     NotificationCenter.default.post(name: .tdoFocusCommand, object: nil)
                 }.keyboardShortcut("l", modifiers: [.command])
                 Divider()
-                Button(pinObserver.isPinned ? "Unpin Window" : "Pin Window") {
+                Button(pinObserver.isPinned ? MacStrings.menuUnpinWindow : MacStrings.menuPinWindow) {
                     pinObserver.isPinned.toggle()
                     pinObserver.applyPin()
                 }

--- a/Sources/tdo-mac/ContentView.swift
+++ b/Sources/tdo-mac/ContentView.swift
@@ -64,7 +64,7 @@ final class ViewModel: ObservableObject {
                 selectedIndex = tasks.isEmpty ? nil : 0
             }
         } catch {
-            status = "error: \(error)"
+            status = MacStrings.error(error)
         }
     }
 
@@ -160,7 +160,7 @@ final class ViewModel: ObservableObject {
                 refresh()
                 status = MacStrings.setTransparency(Int(v))
             } catch {
-                status = "error: \(error)"
+                status = MacStrings.error(error)
             }
             DistributedNotificationCenter.default().post(name: .tdoReloadConfig, object: nil)
             command = ""
@@ -175,7 +175,7 @@ final class ViewModel: ObservableObject {
                 refresh()
                 status = on ? MacStrings.statusPinOn : MacStrings.statusPinOff
             } catch {
-                status = "error: \(error)"
+                status = MacStrings.error(error)
             }
             DistributedNotificationCenter.default().post(name: .tdoReloadConfig, object: nil)
             command = ""
@@ -328,7 +328,7 @@ struct ContentView: View {
             return Text(line).foregroundColor(.green)
         }
         if line.hasPrefix("remove:") { return Text(line).foregroundColor(.red) }
-        if line.hasPrefix("error:") { return Text(line).foregroundColor(.red).bold() }
+        if line.hasPrefix(MacStrings.errorPrefix) { return Text(line).foregroundColor(.red).bold() }
         if line.hasPrefix("note:") { return Text(line).foregroundColor(.gray) }
         if line.contains(" @ ") && line.contains(" status: ") { return Text(line).foregroundColor(.gray) }
         if line.hasPrefix("["), let close = line.firstIndex(of: "]") {

--- a/Sources/tdo-mac/LOCALIZATION.md
+++ b/Sources/tdo-mac/LOCALIZATION.md
@@ -1,0 +1,12 @@
+# macOS UI Strings
+
+The mac app collects all user‑facing copy in [`MacStrings.swift`](MacStrings.swift).
+Update this file to change UI text.
+
+To translate or override these strings:
+
+1. Create a `Localizable.strings` file inside the `tdo-mac` target.
+2. Use the same keys as the English strings defined in `MacStrings`.
+3. Provide localized values for each key.
+
+Keeping strings centralized here ensures copy edits and translations stay in sync.

--- a/Sources/tdo-mac/MacStrings.swift
+++ b/Sources/tdo-mac/MacStrings.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Central repository of macOS UI strings for tdo.
+/// Update the values here to change copy throughout the mac app.
+/// To provide translations, add a `Localizable.strings` file with the same
+/// keys as the strings below.
+enum MacStrings {
+    // MARK: - App and window titles
+    static let appTitle = NSLocalizedString("tdo", comment: "Main app title")
+    static let findTitlePrefix = NSLocalizedString("tdo - find", comment: "Window title prefix for find results")
+    static let fooTitlePrefix = NSLocalizedString("tdo - foo", comment: "Window title prefix for foo results")
+    static let configTitle = NSLocalizedString("tdo - config", comment: "Window title for config view")
+
+    // MARK: - Menus and toolbar
+    static let menuTitle = NSLocalizedString("tdo", comment: "Command menu title")
+    static let menuQuit = NSLocalizedString("Quit tdo", comment: "Quit menu item")
+    static let menuUndoLast = NSLocalizedString("Undo Last", comment: "Undo last menu item")
+    static let menuRefresh = NSLocalizedString("Refresh", comment: "Refresh menu item")
+    static let menuFocusCommand = NSLocalizedString("Focus Command", comment: "Focus command menu item")
+    static let menuPinWindow = NSLocalizedString("Pin Window", comment: "Pin window menu item")
+    static let menuUnpinWindow = NSLocalizedString("Unpin Window", comment: "Unpin window menu item")
+
+    // MARK: - Status messages
+    static let statusPinnedWindow = NSLocalizedString("pinned window", comment: "Status when window pinned")
+    static let statusUnpinnedWindow = NSLocalizedString("unpinned window", comment: "Status when window unpinned")
+    static let statusPinOn = NSLocalizedString("pin on", comment: "Status when pin config enabled")
+    static let statusPinOff = NSLocalizedString("pin off", comment: "Status when pin config disabled")
+    static let statusSetTransparencyFormat = NSLocalizedString("set transparency to %d", comment: "Format for transparency change")
+
+    // MARK: - Placeholder and counts
+    static let commandPlaceholder = NSLocalizedString(
+        "Type a command or just text…  (e.g.  do buy coffee   |   ABC done   |   undo)",
+        comment: "Placeholder for the command input"
+    )
+    static let resultsFormat = NSLocalizedString("%d results", comment: "Format for results count")
+    static let openFormat = NSLocalizedString("%d open", comment: "Format for open tasks count")
+
+    // MARK: - Helpers
+    static func setTransparency(_ value: Int) -> String {
+        String(format: statusSetTransparencyFormat, value)
+    }
+    static func results(_ count: Int) -> String {
+        String(format: resultsFormat, count)
+    }
+    static func openCount(_ count: Int) -> String {
+        String(format: openFormat, count)
+    }
+}
+

--- a/Sources/tdo-mac/MacStrings.swift
+++ b/Sources/tdo-mac/MacStrings.swift
@@ -27,6 +27,12 @@ enum MacStrings {
     static let statusPinOff = NSLocalizedString("pin off", comment: "Status when pin config disabled")
     static let statusSetTransparencyFormat = NSLocalizedString("set transparency to %d", comment: "Format for transparency change")
 
+    // MARK: - Errors
+    static let errorFormat = NSLocalizedString("error: %@", comment: "Generic error message with description")
+    static var errorPrefix: String {
+        errorFormat.components(separatedBy: "%@").first?.trimmingCharacters(in: .whitespaces) ?? "error:"
+    }
+
     // MARK: - Placeholder and counts
     static let commandPlaceholder = NSLocalizedString(
         "Type a command or just text…  (e.g.  do buy coffee   |   ABC done   |   undo)",
@@ -44,6 +50,9 @@ enum MacStrings {
     }
     static func openCount(_ count: Int) -> String {
         String(format: openFormat, count)
+    }
+    static func error(_ error: Error) -> String {
+        String(format: errorFormat, String(describing: error))
     }
 }
 


### PR DESCRIPTION
## Summary
- Centralize macOS UI copy in `MacStrings` and document localization workflow
- Replace hardcoded text in views with `MacStrings` helpers and localized counts
- Update macOS menu items and window titles to reference shared strings

## Testing
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff4205734832e986b5d8b4eaa2376