### PR TITLE
Centralize core user messages

### DIFF
--- a/Sources/TDOCore/AgeLabel.swift
+++ b/Sources/TDOCore/AgeLabel.swift
@@ -19,28 +19,28 @@ public struct AgeLabeler {
     public func label(createdAt: String, now: Date = Date(), calendar: Calendar = .current) -> String {
         guard let created = AgeLabeler.iso.date(from: createdAt) else { return "" }
         let seconds = now.timeIntervalSince(created)
-        if seconds < 60 { return "< 1m" }
+        if seconds < 60 { return CoreStrings.ageLessThanOneMinute }
 
         let minutes = Int(seconds / 60)
-        if minutes <= 15 { return "\(minutes)m" }
-        if minutes < 30 { return "< 30m" }
-        if minutes < 60 { return "< 1h" }
+        if minutes <= 15 { return CoreStrings.ageMinutes(minutes) }
+        if minutes < 30 { return CoreStrings.ageLessThanThirtyMinutes }
+        if minutes < 60 { return CoreStrings.ageLessThanOneHour }
 
         let hours = Int(seconds / 3600)
-        if hours <= 6 { return "\(hours)h" }
+        if hours <= 6 { return CoreStrings.ageHours(hours) }
 
         if calendar.isDate(created, inSameDayAs: now) {
             let h = calendar.component(.hour, from: created)
-            if (5...11).contains(h) { return "Morning" }
-            if (12...13).contains(h) { return "Noon" }
-            return "Evening"
+            if (5...11).contains(h) { return CoreStrings.ageMorning }
+            if (12...13).contains(h) { return CoreStrings.ageNoon }
+            return CoreStrings.ageEvening
         }
 
         let d0 = calendar.startOfDay(for: now)
         let d1 = calendar.startOfDay(for: created)
         let days = calendar.dateComponents([.day], from: d1, to: d0).day ?? 0
-        if days == 1 { return "Yesterday" }
-        if days < 7 { return "\(days)d ago" }
+        if days == 1 { return CoreStrings.ageYesterday }
+        if days < 7 { return CoreStrings.ageDaysAgo(days) }
         return AgeLabeler.mmmDay.string(from: created)
     }
 }

--- a/Sources/TDOCore/CoreStrings.swift
+++ b/Sources/TDOCore/CoreStrings.swift
@@ -85,6 +85,11 @@ public enum CoreStrings {
         "\(path) exists but is not a directory"
     }
 
+    // MARK: - UID errors
+    public static func uidCouldNotGenerate() -> String {
+        "could not generate UID"
+    }
+
     // MARK: - UID resolution notes (unprefixed)
     public static func uidNoOpenTaskMatches(_ raw: String) -> String {
         "no open task matches '\(raw)'"

--- a/Sources/TDOCore/CoreStrings.swift
+++ b/Sources/TDOCore/CoreStrings.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+public enum CoreStrings {
+    // MARK: - Generic prefixes
+    public static func note(_ message: String) -> String { "note: \(message)" }
+    public static func error(_ message: String) -> String { "error: \(message)" }
+
+    // MARK: - Engine top-level
+    public static func errorShellOnlyTopLevel() -> String {
+        error("'shell' is only valid as a top-level command")
+    }
+    public static func notePinHandledByMac() -> String {
+        note("pin/unpin handled by macOS app")
+    }
+    public static func noteExitHandledByMac() -> String {
+        note("exit handled by macOS app")
+    }
+    public static func noteConfigHandledExternally() -> String {
+        note("config handled externally")
+    }
+
+    // MARK: - Engine helpers
+    public static func noteAmbiguousPrefix(prefix: String, chosen: String, choices: [String]) -> String {
+        note("ambiguous prefix '\(prefix)' → chose \(chosen) among [\(choices.joined(separator: ","))]")
+    }
+    public static func noteNoTaskMatches(prefix: String) -> String {
+        note("no task matches '\(prefix)'")
+    }
+    public static func noteEmptyTaskText() -> String {
+        note("empty task text — nothing added")
+    }
+    public static func added(uid: String, text: String, count: String) -> String {
+        "added: [\(uid)] \(text) · \(count)"
+    }
+    public static func listItem(uid: String, text: String) -> String {
+        "[\(uid)] \(text)"
+    }
+    public static func archivedItem(uid: String, text: String, completedAt: String, status: String) -> String {
+        "[\(uid)] \(text) @ \(completedAt) status: \(status)"
+    }
+    public static func detailOpen(uid: String, text: String, count: String, createdAt: String) -> [String] {
+        ["[\(uid)] \(text) · \(count)", "created: \(createdAt)"]
+    }
+    public static func detailArchived(uid: String, text: String, count: String, createdAt: String, completedAt: String, status: String) -> [String] {
+        [
+            "[\(uid)] \(text) · \(count)",
+            "created: \(createdAt)",
+            "completed: \(completedAt)",
+            "status: \(status)",
+        ]
+    }
+    public static func noteNothingToUndo() -> String {
+        note("nothing to undo")
+    }
+    public static func noteCannotUndo(uid: String) -> String {
+        note("cannot undo [\(uid)]; already open")
+    }
+    public static func undo(uid: String, text: String) -> String {
+        "undo: [\(uid)] \(text)"
+    }
+    public static func noteNothingMatched() -> String {
+        note("nothing matched")
+    }
+    public static func done(uid: String, text: String, status: String) -> String {
+        "done: [\(uid)] \(text) status: \(status)"
+    }
+    public static func remove(uid: String, text: String, status: String) -> String {
+        "remove: [\(uid)] \(text) status: \(status)"
+    }
+    public static func noOpenTasksToMarkDone() -> String {
+        "no open tasks to mark done"
+    }
+    public static func countSummary(words: Int, chars: Int, bytes: Int) -> String {
+        "\(words)w \(chars)c \(bytes)b"
+    }
+    public static let statusDone = "done"
+    public static let statusDeleted = "deleted"
+    public static func fileReadFailed(path: String, error: Error) -> String {
+        "Failed to read \(path): \(error)"
+    }
+    public static func fileAtomicWriteFailed(path: String, error: Error) -> String {
+        "Atomic write failed for \(path): \(error)"
+    }
+    public static func envNotDirectory(path: String) -> String {
+        "\(path) exists but is not a directory"
+    }
+
+    // MARK: - UID resolution notes (unprefixed)
+    public static func uidNoOpenTaskMatches(_ raw: String) -> String {
+        "no open task matches '\(raw)'"
+    }
+    public static func uidAmbiguousPrefix(_ raw: String, chosen: String, choices: [String]) -> String {
+        "ambiguous prefix '\(raw)' → chose \(chosen) among [\(choices.joined(separator: ","))]"
+    }
+
+    // MARK: - Age labels
+    public static let ageLessThanOneMinute = "< 1m"
+    public static func ageMinutes(_ m: Int) -> String { "\(m)m" }
+    public static let ageLessThanThirtyMinutes = "< 30m"
+    public static let ageLessThanOneHour = "< 1h"
+    public static func ageHours(_ h: Int) -> String { "\(h)h" }
+    public static let ageMorning = "Morning"
+    public static let ageNoon = "Noon"
+    public static let ageEvening = "Evening"
+    public static let ageYesterday = "Yesterday"
+    public static func ageDaysAgo(_ d: Int) -> String { "\(d)d ago" }
+
+    // MARK: - Parser
+    public static let noCommand = "no command"
+    public static func unknownCommand(_ s: String) -> String { "unknown command: \(s)" }
+}
+

--- a/Sources/TDOCore/Engine.swift
+++ b/Sources/TDOCore/Engine.swift
@@ -51,9 +51,9 @@ public struct Engine {
                 return ([CoreStrings.noteConfigHandledExternally()], false, .ok)
             }
         } catch let e as FileIOError {
-            return ([CoreStrings.error("\(e)")], false, .ioError)
+            return ([CoreStrings.error(e.description)], false, .ioError)
         } catch let e as UIDError {
-            return ([CoreStrings.error("\(e)")], false, .unexpected)
+            return ([CoreStrings.error(e.description)], false, .unexpected)
         } catch let e as ParseError {
             return ([CoreStrings.error(e.description)], false, .userError)
         } catch {

--- a/Sources/TDOCore/Env.swift
+++ b/Sources/TDOCore/Env.swift
@@ -59,7 +59,7 @@ public struct Env {
         } else if !isDir.boolValue {
             throw NSError(
                 domain: "Env", code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "\(url.path) exists but is not a directory"])
+                userInfo: [NSLocalizedDescriptionKey: CoreStrings.envNotDirectory(path: url.path)])
         }
     }
 

--- a/Sources/TDOCore/FileIO.swift
+++ b/Sources/TDOCore/FileIO.swift
@@ -1,8 +1,15 @@
 import Foundation
 
-enum FileIOError: Error {
+enum FileIOError: Error, CustomStringConvertible {
     case atomicWriteFailed(String)
     case readFailed(String)
+
+    var description: String {
+        switch self {
+        case .atomicWriteFailed(let s), .readFailed(let s):
+            return s
+        }
+    }
 }
 
 struct FileIO {

--- a/Sources/TDOCore/FileIO.swift
+++ b/Sources/TDOCore/FileIO.swift
@@ -9,7 +9,7 @@ struct FileIO {
     static func readLines(_ url: URL) throws -> [String] {
         let data: Data
         do { data = try Data(contentsOf: url) } catch {
-            throw FileIOError.readFailed("Failed to read \(url.path): \(error)")
+            throw FileIOError.readFailed(CoreStrings.fileReadFailed(path: url.path, error: error))
         }
         guard let s = String(data: data, encoding: .utf8) else { return [] }
         return s.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(
@@ -39,7 +39,7 @@ struct FileIO {
         } catch {
             // best effort cleanup
             try? FileManager.default.removeItem(at: tmp)
-            throw FileIOError.atomicWriteFailed("Atomic write failed for \(url.path): \(error)")
+            throw FileIOError.atomicWriteFailed(CoreStrings.fileAtomicWriteFailed(path: url.path, error: error))
         }
     }
 

--- a/Sources/TDOCore/Parser.swift
+++ b/Sources/TDOCore/Parser.swift
@@ -25,8 +25,8 @@ enum ParseError: Error, CustomStringConvertible {
     case unknownCommand(String)
     var description: String {
         switch self {
-        case .empty: return "no command"
-        case .unknownCommand(let s): return "unknown command: \(s)"
+        case .empty: return CoreStrings.noCommand
+        case .unknownCommand(let s): return CoreStrings.unknownCommand(s)
         }
     }
 }

--- a/Sources/TDOCore/UID.swift
+++ b/Sources/TDOCore/UID.swift
@@ -1,7 +1,14 @@
 import Foundation
 
-enum UIDError: Error {
+enum UIDError: Error, CustomStringConvertible {
     case couldNotGenerate
+
+    var description: String {
+        switch self {
+        case .couldNotGenerate:
+            return CoreStrings.uidCouldNotGenerate()
+        }
+    }
 }
 
 struct UID {

--- a/Sources/TDOCore/UID.swift
+++ b/Sources/TDOCore/UID.swift
@@ -69,14 +69,13 @@ struct UID {
 
             let candidates = open.filter { $0.uid.hasPrefix(pfx) }
             if candidates.isEmpty {
-                notes.append("no open task matches '\(raw)'")
+                notes.append(CoreStrings.uidNoOpenTaskMatches(raw))
             } else if candidates.count == 1 {
                 results.append(candidates[0])
             } else {
                 // ambiguous → choose newest by createdAt, note the choice
                 let chosen = candidates.max(by: { $0.createdAt < $1.createdAt })!
-                let list = candidates.map { $0.uid }.joined(separator: ",")
-                notes.append("ambiguous prefix '\(raw)' → chose \(chosen.uid) among [\(list)]")
+                notes.append(CoreStrings.uidAmbiguousPrefix(raw, chosen: chosen.uid, choices: candidates.map { $0.uid }))
                 results.append(chosen)
             }
         }


### PR DESCRIPTION
## Summary
- introduce `CoreStrings` to store all user-facing messages in one place
- refactor core components to use `CoreStrings` helpers
- format errors and notes consistently across the engine

## Testing
- `swift test` (fails: no tests found; build succeeded)


------
https://chatgpt.com/codex/tasks/task_e_68aff41da8e4832e8b4e3b3352211fdd