### PR TITLE
Default tdo to list tasks by default

### DIFF
--- a/Sources/tdo/main.swift
+++ b/Sources/tdo/main.swift
@@ -54,6 +54,12 @@ func runShell(env initialEnv: Env) -> Int32 {
     let engine = Engine()
     let renderer = makeRenderer()
 
+    if let tasks = try? engine.openTasks(env: env) {
+        renderer.printBlock(renderer.renderOpenList(tasks))
+    } else {
+        renderer.printBlock(["error: could not load tasks"])
+    }
+
     while true {
         fputs("> ", stdout)
         fflush(stdout)
@@ -149,7 +155,7 @@ func runEntry() -> Int32 {
     args.removeFirst()
 
     let (paths, restRaw) = splitGlobalFlags(args)
-    let rest = restRaw.isEmpty ? ["shell"] : restRaw
+    let rest = restRaw.isEmpty ? ["list"] : restRaw
 
     let env: Env
     do { env = try Env(activePath: paths.0, archivePath: paths.1) } catch {

--- a/Sources/tdo/main.swift
+++ b/Sources/tdo/main.swift
@@ -163,19 +163,10 @@ func runEntry() -> Int32 {
     }
 
     // Default to listing tasks when no command is provided
-    if rest.isEmpty {
-        let engine = Engine()
-        let renderer = makeRenderer()
-        if let tasks = try? engine.openTasks(env: env) {
-            renderer.printBlock(renderer.renderOpenList(tasks))
-        } else {
-            renderer.printBlock(["error: could not load tasks"])
-        }
-        return ExitCode.ok.rawValue
-    }
+    let argv = rest.isEmpty ? ["list"] : rest
 
     do {
-        let cmd = try Parser.parse(argv: rest)
+        let cmd = try Parser.parse(argv: argv)
         let engine = Engine()
         let renderer = makeRenderer()
 


### PR DESCRIPTION
## Summary
- list tasks when `tdo` is run without arguments
- show the current task list before entering interactive `tdo shell`

## Testing
- `swift test` *(fails: no tests found)*
- `swift build -c release`


------
https://chatgpt.com/codex/tasks/task_e_68affb538bb4832ebddf56012ada24d0